### PR TITLE
Update price variable

### DIFF
--- a/blockbestsellers.php
+++ b/blockbestsellers.php
@@ -266,7 +266,7 @@ class BlockBestSellers extends Module
 		$currency = new Currency($params['cookie']->id_currency);
 		$usetax = (Product::getTaxCalculationMethod((int)$this->context->customer->id) != PS_TAX_EXC);
 		foreach ($result as &$row)
-			$row['price'] = Tools::displayPrice(Product::getPriceStatic((int)$row['id_product'], $usetax), $currency);
+			$row['price'] = Product::getPriceStatic((int)$row['id_product'], $usetax);
 
 		return $result;
 	}


### PR DESCRIPTION
I suggest removing Tools::displayPrice for products $row['price'].
It's not necessary to do it here and it also avoids making math calculations with the variable. 
Thanks.